### PR TITLE
update according to latest PA scripting addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
 # PythonAnywhere SSL Certificate Renewal Script
-A python script for use with www.pythonanywhere.com that checks to see if an SSL script is unexpired. If it is expired, the script generates a new certificate and emails the support staff at pythonanywhere.com the details necessary for activative the newly generated script.
+A python script for use with www.pythonanywhere.com that checks to see if SSL certificates are about to expire. If they are, the script generates new certificates and installs them.
 
 ### Setup
 If you haven't set up SSL on your domain for use with pythonanywhere please see [this page](https://help.pythonanywhere.com/pages/LetsEncrypt/) for details on how to do so.
 If you have, then follow these steps to set up the automatic renewal script contained in this repository:
 1. Clone this repository inside of your home directory in python anywhere
-2. Edit the renew_ssl.py file and insert the proper values in the CONFIG dictionary.  Be sure to do this carefully! If you insert improper values into this dictionary, the script will not work.  The following are descriptions of each field in the config dictionary, examples are given as needed:
-    * SMTP_SERVER - e.g. smtp.gmail.com
-    * SMTP_USERNAME - Most likely your email address without the "@domain.com" part
-    * SMPT_PASSWORD - The same password associated with your email address
-    * SENDER_EMAIL_ADDRESS - Your email address
-    * RECIEVER_EMAIL_ADDRESS - This should always be set to support@pythonanywhere.com
-    * PYTHONANYWHERE_USERNAME - Your pythonanywhere username
-    * CERTIFICATE_DIR - The directory for your SSL certificates.  e.g. /home/username/letsencrypt/www.yourdomain.com
-    * DOMAIN_NAME - The domain name of your website. e.g. www.yourdomain.com
+2. Edit the renew_ssl.py file and insert the domains for which you have installed certificates values in the DOMAIN_NAMES list, e.g. `DOMAIN_NAMES = [www.yourdomain.com, anotherdomain.org]`. Be sure to do this carefully! If you insert improper values here, the script will not work as intended. You can also change the DAYS_BEFORE_RENEWAL value to something you prefer.
 3. On your pythonanywhere dashboard, click on the "Tasks" tab, and create a task to run the renew_ssl.py script at whatever time interval you prefer.
 
 If you configured everything properly, the script should be all set to go and you can forget about manually generating openssl certificates for as long as you'd like!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A python script for use with www.pythonanywhere.com that checks to see if SSL ce
 If you haven't set up SSL on your domain for use with pythonanywhere please see [this page](https://help.pythonanywhere.com/pages/LetsEncrypt/) for details on how to do so.
 If you have, then follow these steps to set up the automatic renewal script contained in this repository:
 1. Clone this repository inside of your home directory in python anywhere
-2. Edit the renew_ssl.py file and insert the domains for which you have installed certificates values in the DOMAIN_NAMES list, e.g. `DOMAIN_NAMES = [www.yourdomain.com, anotherdomain.org]`. Be sure to do this carefully! If you insert improper values here, the script will not work as intended. You can also change the DAYS_BEFORE_RENEWAL value to something you prefer.
+2. Edit the renew_ssl.py file and insert the domains for which you have installed certificates values in the DOMAIN_NAMES list, e.g. `DOMAIN_NAMES = ["www.yourdomain.com", "anotherdomain.org"]`. Be sure to do this carefully! If you insert improper values here, the script will not work as intended. You can also change the DAYS_BEFORE_RENEWAL value to something you prefer.
 3. On your pythonanywhere dashboard, click on the "Tasks" tab, and create a task to run the renew_ssl.py script at whatever time interval you prefer.
 
 If you configured everything properly, the script should be all set to go and you can forget about manually generating openssl certificates for as long as you'd like!

--- a/renew_ssl.py
+++ b/renew_ssl.py
@@ -12,7 +12,7 @@ Beware: This is for renewal. For initial installation, the steps in https://help
 """
 
 DOMAIN_NAMES = []  # FILL THIS IN
-DAYS_BEFORE_RENEWAL = 3
+DAYS_BEFORE_EXPIRE = 3
 
 LBL = "[PA-SSL-RENEWAL]"
 
@@ -54,7 +54,7 @@ def install_new_certificate(domain_name: str):
 if __name__ == "__main__":
 
     for domain in DOMAIN_NAMES:
-        if certificate_expires_soon(domain, in_days=DAYS_BEFORE_RENEWAL):
+        if certificate_expires_soon(domain, in_days=DAYS_BEFORE_EXPIRE):
             generate_new_certificate(domain)
             install_new_certificate(domain)
         else:

--- a/renew_ssl.py
+++ b/renew_ssl.py
@@ -1,61 +1,61 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import datetime
 import os
-import smtplib
 import subprocess
 
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+"""
+This script can be run to renew several LetsEncrypt SSL certificates on PythonAnywhere.
+For configuration, all we need is to configure the domain names.
+
+Beware: This is for renewal. For initial installation, the steps in https://help.pythonanywhere.com/pages/LetsEncrypt/
+        should be followed for each domain, so that everything (PA scripts, certificate directories) is where expected.
+"""
+
+DOMAIN_NAMES = []  # FILL THIS IN
+DAYS_BEFORE_RENEWAL = 3
+
+LBL = "[PA-SSL-RENEWAL]"
 
 
-CONFIG = {
-    "SMTP_SERVER": "",
-    "SMTP_USERNAME": "",
-    "SMTP_PASSWORD": "",
-    "SENDER_EMAIL_ADDRESS": "",
-    "RECIEVER_EMAIL_ADDRESS": "",
-    "PYTHONANYWHERE_USERNAME": "",
-    "CERTIFICATE_DIR": "",
-    "DOMAIN_NAME": ""
-}
-
-
-def certificate_expired():
-    date_parts = subprocess.check_output("openssl x509 -enddate -noout -in ~/letsencrypt/{}/cert.pem".format(CONFIG['DOMAIN_NAME']), shell=True).strip("notAfter=").split(" ") 
-    date_string = date_parts[1]+date_parts[0]+date_parts[3]
+def certificate_expires_soon(domain_name: str, in_days=3):
+    date_parts = (
+        subprocess.check_output(
+            "openssl x509 -enddate -noout -in ~/letsencrypt/{}/cert.pem".format(
+                domain_name
+            ),
+            shell=True,
+            universal_newlines=True,
+        )
+        .replace("notAfter=", "")
+        .split()
+    )
+    date_string = date_parts[1] + date_parts[0] + date_parts[3]
     expire_date = datetime.datetime.strptime(date_string, "%d%b%Y")
 
-    if(datetime.datetime.now() + datetime.timedelta(days=3) > expire_date):
+    if datetime.datetime.now() + datetime.timedelta(days=in_days) > expire_date:
+        print("%s Certificate for %s expires soon (%s)" % (LBL, domain_name, expire_date))
         return True
     return False
 
 
-def generate_new_certificate():
-    os.system("~/dehydrated/dehydrated --cron --config ~/letsencrypt/config --domain {} --out ~/letsencrypt --challenge http-01 ".format(CONFIG['DOMAIN_NAME']))
+def generate_new_certificate(domain_name: str):
+    print("%s Generating certificate for  %s ..." % (LBL, domain_name))
+    os.system(
+        "~/dehydrated/dehydrated --cron --config ~/letsencrypt/config"
+        " --domain {} --out ~/letsencrypt --challenge http-01 ".format(domain_name)
+    )
 
 
-def send_renewal_email():
-    body = """
-    Username: {}
-    Certificate Directory: {}
-    Domain Name: {}
-    
-    Thank you!""".format(CONFIG['PYTHONANYWHERE_USERNAME'], CONFIG['CERTIFICATE_DIR'], CONFIG['DOMAIN_NAME'])
-
-    email = MIMEMultipart()
-    email['Subject'] = 'SSL Certificate Renewal'
-    email.attach(MIMEText(body, 'plain'))
-
-    smtp = smtplib.SMTP(CONFIG['SMTP_SERVER'], 587)
-    smtp.ehlo()
-    smtp.starttls()
-    smtp.login(CONFIG['SMTP_USERNAME'],CONFIG['SMTP_PASSWORD'])
-    smtp.sendmail(CONFIG['SENDER_EMAIL_ADDRESS'], CONFIG['RECIEVER_EMAIL_ADDRESS'], email.as_string())
-    smtp.quit()
+def install_new_certificate(domain_name: str):
+    print("%s Installing certificate for  %s ..." % (LBL, domain_name))
+    os.system("pa_install_webapp_letsencrypt_ssl.py {}".format(domain_name))
 
 
-if certificate_expired():
-    generate_new_certificate()
-    send_renewal_email()
-else:
-    print("Current certificates are up to date!")
+if __name__ == "__main__":
+
+    for domain in DOMAIN_NAMES:
+        if certificate_expires_soon(domain, in_days=DAYS_BEFORE_RENEWAL):
+            generate_new_certificate(domain)
+            install_new_certificate(domain)
+        else:
+            print("%s Current certificate for %s is up to date!" % (LBL, domain))


### PR DESCRIPTION
I made this update because [PythonAnywhere now supports self-installation of SSL certificates](https://blog.pythonanywhere.com/168/).

Also included:
* enable checking multiple domains
* require python3 according to PA scripts running on python3 only
* implement suggestion from issue #1